### PR TITLE
128 django system check failure with notificationpreferenceuser

### DIFF
--- a/forum/forum/settings.py
+++ b/forum/forum/settings.py
@@ -228,6 +228,7 @@ LOGGING = {
         'django': {
             'handlers': ['console', 'forum_file'],
             'level': 'WARNING',
+            'propagate': False,
         },
         'django.db.backends': {
             'handlers': ['console', 'database_file'],

--- a/forum/forum/settings.py
+++ b/forum/forum/settings.py
@@ -238,7 +238,7 @@ LOGGING = {
         '': {
             'handlers': ['console', 'forum_file'],
             'level': 'DEBUG',
-            'propagate': True,
+            'propagate': False,
         },
     },
 }

--- a/forum/notifications/models.py
+++ b/forum/notifications/models.py
@@ -1,6 +1,7 @@
 from django.db import models
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
+User = get_user_model()
 
 class NotificationType(models.Model):
     name = models.CharField(max_length=100, unique=True)


### PR DESCRIPTION
Fix user model reference in NotificationPreference and prevent log duplication

- Updated NotificationPreference to use `settings.AUTH_USER_MODEL`  with 'get_user_model' to resolve system check error.
- Disabled log propagation to the root logger to prevent log duplication.

[#128](https://github.com/Project-Stage-Academy/UA1303/issues/128)